### PR TITLE
feature/DAM-275

### DIFF
--- a/modules/ec2_no_replace_instance/main.tf
+++ b/modules/ec2_no_replace_instance/main.tf
@@ -1,4 +1,5 @@
 resource "aws_instance" "instance" {
+  count                       = "${var.deploy ? 1 : 0 }"
   ami                         = "${var.ami_id}"
   instance_type               = "${var.instance_type}"
   subnet_id                   = "${var.subnet_id}"

--- a/modules/ec2_no_replace_instance/output.tf
+++ b/modules/ec2_no_replace_instance/output.tf
@@ -1,19 +1,19 @@
 output "private_ip" {
-  value = "${aws_instance.instance.private_ip}"
+  value = "${aws_instance.instance.*.private_ip}"
 }
 
 output "private_dns" {
-  value = "${aws_instance.instance.private_dns}"
+  value = "${aws_instance.instance.*.private_dns}"
 }
 
 output "public_ip" {
-  value = "${aws_instance.instance.public_ip}"
+  value = "${aws_instance.instance.*.public_ip}"
 }
 
 output "public_dns" {
-  value = "${aws_instance.instance.public_dns}"
+  value = "${aws_instance.instance.*.public_dns}"
 }
 
 output "instance_id" {
-  value = "${aws_instance.instance.id}"
+  value = "${aws_instance.instance.*.id}"
 }

--- a/modules/ec2_no_replace_instance/output.tf
+++ b/modules/ec2_no_replace_instance/output.tf
@@ -1,19 +1,19 @@
 output "private_ip" {
-  value = "${aws_instance.instance.*.private_ip}"
+  value = "${aws_instance.instance.0.private_ip}"
 }
 
 output "private_dns" {
-  value = "${aws_instance.instance.*.private_dns}"
+  value = "${aws_instance.instance.0.private_dns}"
 }
 
 output "public_ip" {
-  value = "${aws_instance.instance.*.public_ip}"
+  value = "${aws_instance.instance.0.public_ip}"
 }
 
 output "public_dns" {
-  value = "${aws_instance.instance.*.public_dns}"
+  value = "${aws_instance.instance.0.public_dns}"
 }
 
 output "instance_id" {
-  value = "${aws_instance.instance.*.id}"
+  value = "${aws_instance.instance.0.id}"
 }

--- a/modules/ec2_no_replace_instance/variables.tf
+++ b/modules/ec2_no_replace_instance/variables.tf
@@ -31,3 +31,10 @@ variable "tags" {
 variable "root_device_size" {
   default = "8"
 }
+
+# whether to deploy an instance of this module
+# Allow overriding for diff envs when the code base uses static definitions of the number of ec2 instances to deploy
+# and we don't want to replace running instances
+variable "deploy" {
+  default = true
+}


### PR DESCRIPTION
Add a deploy flag to allow calling components to deploy differing numbers of the ec2_no_replace_instance module
Flag defaults to true so existing consumers should be unaffected
Had to modify the output to use the splat identifier, but as this module only ever builds a single instance, this should have no impact and be fully backwards compatible.