### PR TITLE
Fixing the specification of the AWS provider from ~>: pessimistic con…

### DIFF
--- a/components/monitoring/README.md
+++ b/components/monitoring/README.md
@@ -8,7 +8,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.region}"
-  version = "~> 1.16"
+  version = ">= 1.16"
 }
 
 #-------------------------------------------------------------

--- a/components/monitoring/elasticsearch-cluster/main.tf
+++ b/components/monitoring/elasticsearch-cluster/main.tf
@@ -5,7 +5,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.region}"
-  version = "~> 1.16"
+  version = ">= 1.16"
 }
 
 locals {

--- a/components/monitoring/monitoring-server/main.tf
+++ b/components/monitoring/monitoring-server/main.tf
@@ -5,7 +5,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.region}"
-  version = "~> 1.16"
+  version = ">= 1.16"
 }
 
 locals {

--- a/modules/nfs-server/main.tf
+++ b/modules/nfs-server/main.tf
@@ -5,7 +5,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.region}"
-  version = "~> 1.16"
+  version = ">= 1.16"
 }
 
 ####################################################


### PR DESCRIPTION
…straint operator, constraining both the oldest and newest version allowed.

To Re-usable modules should constrain only the minimum allowed version, such as >= 0.12.0. This specifies the earliest version that the module is compatible with while leaving the user of the module flexibility to upgrade to newer versions of Terraform without altering the module.