### PR TITLE
Fix owners id

### DIFF
--- a/modules/nfs-server/main.tf
+++ b/modules/nfs-server/main.tf
@@ -16,6 +16,7 @@ provider "aws" {
 ### Getting the latest amazon ami
 #-------------------------------------------------------------
 data "aws_ami" "amazon_ami" {
+  owners      = ["895523100917"]
   most_recent = true
 
   filter {
@@ -93,6 +94,3 @@ locals {
   mount_point         =  "/data"
   volume_group_name   = "${local.app_name}.vg"
 }
-
-
-


### PR DESCRIPTION
Fixes:
`Error: module.activemq-nfs.data.aws_ami.amazon_ami: "owners": required field is not set`