### PR TITLE
Updated calendar creation resource to only trigger when inputs are changed

### DIFF
--- a/modules/auto-start/calendar/ssm.tf
+++ b/modules/auto-start/calendar/ssm.tf
@@ -104,7 +104,10 @@ DOC
 
 resource "null_resource" "create_calendar" {
   triggers = {
-    always_run = timestamp()
+    # Trigger an update only when the input values change:
+    region               = var.region
+    calendar_name        = local.calendar_name
+    calender_content_doc = var.calender_content_doc
   }
   provisioner "local-exec" {
     command = "sh scripts/create_calendar.sh ${var.calender_content_doc} ${local.calendar_name} ${var.region}"


### PR DESCRIPTION
Tested in delius-core-dev.

1. First apply forces replacement:
```
  # module.calendar.null_resource.create_calendar must be replaced
-/+ resource "null_resource" "create_calendar" {
      ~ id       = "7710116841605799181" -> (known after apply)
      ~ triggers = { # forces replacement
          - "always_run"           = "2020-11-11T10:01:36Z" -> null
          + "calendar_name"        = "delius-core-dev-calendar"
          + "calender_content_doc" = "file://files/calendar_content"
          + "region"               = "eu-west-2"
        }
    }

Plan: 1 to add, 0 to change, 1 to destroy.

module.calendar.null_resource.create_calendar: Destroying... [id=7710116841605799181]
module.calendar.null_resource.create_calendar: Destruction complete after 0s
module.calendar.null_resource.create_calendar: Creating...
module.calendar.null_resource.create_calendar: Provisioning with 'local-exec'...
module.calendar.null_resource.create_calendar (local-exec): Executing: ["/bin/sh" "-c" "sh scripts/create_calendar.sh file://files/calendar_content delius-core-dev-calendar eu-west-2"]
module.calendar.null_resource.create_calendar: Creation complete after 2s [id=427545949344817336]

Apply complete! Resources: 1 added, 0 changed, 1 destroyed.
Releasing state lock. This may take a few moments...

Outputs:

calendar_name = delius-core-dev-calendar
```


2. Subsequent applies don't trigger any change (unless calendar_name or calender_content_doc are updated):
```
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

calendar_name = delius-core-dev-calendar
```